### PR TITLE
Prevent new problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Do not commit credentials (again)!
+config.cfg

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Updates the IPs for several DNS records on CloudFlare using their native API
 
 # Howto:
+* rename options.cfg.template to options.cfg
 * change options.cfg
 * run ``python main.py`` to see if it works
 

--- a/options.cfg
+++ b/options.cfg
@@ -1,6 +1,0 @@
-[Options]
-api_key = 0d5a4ce1ec5ae97343e7eb1f5773e781a9c63
-email = framescape@gmail.com
-domain = ddienlin.de
-sub_domain_names = ['sab.ddienlin.de', 'son.ddienlin.de', 'www.ddienlin.de']
-

--- a/options.cfg.template
+++ b/options.cfg.template
@@ -1,0 +1,5 @@
+[Options]
+api_key = your api key
+email = your cloudflare email address 
+domain = your domain name
+sub_domain_names = ['your', 'subdomains', 'here']


### PR DESCRIPTION
In order to prevent CloudFlare credentials being commited (again) some measures:
1. Don't commit config.cfg, instead put a template in the repository;
2. Put config.cfg in .gitignore, so it will not be commited again;

If you change config.cfg to JSON remember to update .gitignore and the template. Also **hurry up** and [change your API key](https://www.cloudflare.com/a/account/my-account).
